### PR TITLE
fix/dont require buildkit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,22 +4,30 @@ default_language_version:
   python: python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-merge-conflict
       - id: check-yaml
         exclude: "charts/.*"
         args:
           - --allow-multiple-documents
-      - id: check-added-large-files
-      - id: check-json
-      - id: check-merge-conflict
       - id: detect-aws-credentials
+        args:
+          - --allow-missing-credentials
       - id: detect-private-key
+      - id: end-of-file-fixer
       - id: mixed-line-ending
+      - id: no-commit-to-branch
+        args:
+          - --pattern
+          - '^(?!((fix|feature|refactor)\/[a-zA-Z0-9\-]+)$).*'
+      - id: trailing-whitespace
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.27.0
+    rev: v2.31.0
     hooks:
       - id: commitizen
         stages: [commit-msg]
@@ -27,8 +35,13 @@ repos:
     rev: v0.1.17
     hooks:
       - id: helmlint
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: 'v2.7.1'  # Use the sha / tag you want to point at
+    hooks:
+      - id: prettier
+        files: ".*(js|jsx|ts|tsx)"
   - repo: https://github.com/gherynos/pre-commit-java
-    rev: v0.1.0
+    rev: v0.2.0
     hooks:
       - id: checkstyle
         args:
@@ -37,10 +50,8 @@ repos:
         exclude: ".*/src/test/.*"
       - id: cpd
         exclude: ".*/src/test/.*"
-      - id: pmd
-        exclude: ".*/src/test/.*"
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 2.1.6
+    rev: 3.0.0
     hooks:
       - id: forbid-binary
         exclude: ".*.(png|jpg|jpeg)$"
@@ -48,8 +59,8 @@ repos:
         args:
           - -a
           - -x
-          - -e
-          - SC1072,SC1073
+          - -P
+          - SCRIPTDIR
       - id: script-must-have-extension
       - id: script-must-not-have-extension
       - id: shfmt
@@ -62,32 +73,12 @@ repos:
     rev: v0.11.0
     hooks:
       - id: markdownlint
-        args:
-          - --config
-          - .mdlrc
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.15.0
+    rev: v8.22.0
     hooks:
       - id: eslint
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
-    hooks:
-      - id: check-added-large-files
-      - id: check-case-conflict
-      - id: check-executables-have-shebangs
-      - id: check-json
-      - id: check-merge-conflict
-      - id: detect-aws-credentials
-      - id: detect-private-key
-      - id: end-of-file-fixer
-      - id: mixed-line-ending
-      - id: no-commit-to-branch
-        args:
-          - --pattern
-          - '^(?!((fix|feature)\/[a-zA-Z0-9\-]+)$).*'
-      - id: trailing-whitespace
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.2.0
+    rev: v1.3.1
     hooks:
       - id: forbid-tabs
         exclude: "^(.*/?Makefile|.*.mk|.*.go)$"
@@ -103,7 +94,7 @@ repos:
       - id: fmt
       - id: cargo-check
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.26.3
+    rev: v1.27.1
     hooks:
       - id: yamllint
         exclude: ".*/templates/.*"
@@ -114,9 +105,25 @@ repos:
         files: docker-compose.*y[a]{0,1}ml$
       - id: docker-compose-check
         files: "^docker/.*yaml$"
+      - id: hadolint
+        files: ".*.docker$"
+        args:
+          - --ignore
+          - DL3008
+          - --ignore
+          - DL3013
+      - id: hadolint
+        files: "Dockerfile.*"
+        args:
+          - --ignore
+          - DL3008
+          - --ignore
+          - DL3013
   - repo: https://gitlab.com/daverona/pre-commit/cpp
-    rev: 0.8.0 # use the most recent version
+    rev: 0.8.0
     hooks:
-      - id: docker-cppcheck # cppcheck in Docker container
+      - id: docker-clang-format
+      - id: cpplint
+      - id: docker-cppcheck
         args:
           - --force

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ $(MARKERS)/example-release-$(1): $(MARKERS)
 
 $(1)/chronicle.graphql: $(MARKERS)/example-inmem-$(1)
 	docker run --env RUST_LOG=debug chronicle-$(1)-inmem:$(ISOLATION_ID) \
-		chronicle export-schema > $(1)/chronicle.graphql
+		export-schema > $(1)/chronicle.graphql
 
 clean-graphql-$(1):
 	rm -f $(1)/chronicle.graphql

--- a/docker/chronicle.dockerfile
+++ b/docker/chronicle.dockerfile
@@ -13,7 +13,10 @@ RUN if [ "${RELEASE}" = "yes" ]; then \
 
 WORKDIR /
 FROM ubuntu:focal AS example-chronicle-inmem
-COPY --from=domain-inmem /usr/local/bin/chronicle /usr/local/bin
-COPY --chmod=755 --chown=root:bin entrypoint /entrypoint
+COPY --from=domain-inmem --chown=root:bin /usr/local/bin/chronicle /usr/local/bin
+COPY --chown=root:bin entrypoint /entrypoint
+RUN chmod 755 \
+  /entrypoint \
+  /usr/local/bin/chronicle
 
 ENTRYPOINT [ "/entrypoint" ]


### PR DESCRIPTION

- ci(pre-commit): update to latest config
  Housekeeping

- fix(docker): remove buildkit specific instructions
   The chmod option is buildkit specific and not everywhere has buildkit.  

- fix(make): correct sdl command
  graphql generation was still referring to the old docker entrypoint style
