### PR TITLE
fix(docker): use buildkit, which makes errrs more obvious

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ ARCH_TYPE ?= $(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
 CHRONICLE_BUILDER_IMAGE ?= blockchaintp/chronicle-builder-$(ARCH_TYPE)
 CHRONICLE_VERSION ?= BTP2.1.0
 
+export DOCKER_BUILDKIT=1
+export COMPOSE_DOCKER_CLI_BUILD=1
 
 CLEAN_DIRS := $(CLEAN_DIRS)
 

--- a/docker/chronicle.dockerfile
+++ b/docker/chronicle.dockerfile
@@ -11,15 +11,15 @@ RUN if [ "${RELEASE}" = "yes" ]; then \
       cargo build --release --frozen --features "${FEATURES}" --bin chronicle; \
     else \
       cargo build --release --frozen --bin chronicle; \
-    fi; \
-    cp target/release/chronicle /usr/local/bin/; \
+    fi \
+    && cp target/release/chronicle /usr/local/bin/; \
   else \
     if [ -n "${FEATURES}" ]; then \
       cargo build --frozen --features "${FEATURES}" --bin chronicle; \
     else \
       cargo build --frozen --bin chronicle; \
-    fi; \
-    cp target/debug/chronicle /usr/local/bin/; \
+    fi \
+    && cp target/debug/chronicle /usr/local/bin/; \
   fi;
 
 WORKDIR /


### PR DESCRIPTION
This PR forces the build to use buildkit.  

The existing build effectively swallows any error log messages if there is a problem with the yaml, giving you just a relatively unhelpful error code.  Using buildkit is the cleanest way to let those log messages through and give a better indication of what they need to do to fix.  This is even more important when the linter comes in.

Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>
